### PR TITLE
Use `usize` instead of `u64` when calling Fvad to fix compilation on 32-bit ARMv7

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ impl Fvad {
     /// - `Some(false)` on no active voice detection
     /// - `None` on invalid frame length
     pub fn is_voice_frame(&mut self, frame: &[i16]) -> Option<bool> {
-        match unsafe { ffi::fvad_process(self.fvad, frame.as_ptr(), frame.len() as u64) } {
+        match unsafe { ffi::fvad_process(self.fvad, frame.as_ptr(), frame.len()) } {
             -1 => None,
             0 => Some(false),
             1 => Some(true),


### PR DESCRIPTION
Fixes #1.

Depends on https://github.com/rvolosatovs/libfvad-sys/pull/1.